### PR TITLE
fix setRequestingSid() function call

### DIFF
--- a/generateCpp.cpp
+++ b/generateCpp.cpp
@@ -1238,7 +1238,7 @@ void AST::generateStubSource(Formatter& out, const Interface* iface) const {
         << "_hidl_impl, {SCHED_NORMAL, 0});\n";
     out << "mSchedPolicy = prio.sched_policy;\n";
     out << "mSchedPriority = prio.prio;\n";
-    out << "setRequestingSid(::android::hardware::details::gServiceSidMap.get(_hidl_impl, false));\n";
+    out << "setRequestingSid(::android::hardware::details::gServiceSidMap.get(_hidl_impl), false);\n";
     out.unindent();
 
     out.unindent();


### PR DESCRIPTION
this small logical error is creating many .cpp with wrong funtion call and wasting hours of time with errors